### PR TITLE
allow range for dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,19 +3,22 @@
   "version": "0.5.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest"
   },
   "dependencies": {
-    "@types/node": "18.16.3",
+    "@types/node": "~18.16.3",
     "axios": "^1.4.0",
-    "typescript": "5.0.4"
+    "typescript": "~5.0.4"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.1",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0"
+    "@types/jest": "~29.5.1",
+    "jest": "~29.5.0",
+    "ts-jest": "~29.1.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,12 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@types/jest': ^29.5.1
-  '@types/node': 18.16.3
+  '@types/jest': ~29.5.1
+  '@types/node': ~18.16.3
   axios: ^1.4.0
-  jest: ^29.5.0
-  ts-jest: ^29.1.0
-  typescript: 5.0.4
+  jest: ~29.5.0
+  ts-jest: ~29.1.0
+  typescript: ~5.0.4
 
 dependencies:
   '@types/node': registry.npmjs.org/@types/node/18.16.3


### PR DESCRIPTION
Adds ranges for versions, so we don't have to use the exact version in the application using the package. This also means we don't have to update the package whenever a dependency has a new version.

Additionally I think for some dependencies it might make sense to specify them as peer dependencies... 