### PR TITLE
Fix filters and populates

### DIFF
--- a/lib/strapiEntity.ts
+++ b/lib/strapiEntity.ts
@@ -73,13 +73,13 @@ export class StrapiEntity<T> {
 			GenericStrapiData<GenericStrapiEntity<any>[]>
 		>(path ? path : this.path, {
 			params: {
-				...(populates ?? {}),
-				...(filters ?? {}),
+				...populates,
+				...filters,
 				"pagination[pageSize]": this.pageSize,
 				"pagination[page]": page,
 			},
 		});
-		if (response.data.metadata?.pagination?.pageCount > page) {
+		if (response.data?.metadata?.pagination?.pageCount > page) {
 			const additionalData = await this.queryStrapi({
 				path: path,
 				populates: populates,
@@ -103,25 +103,28 @@ export class StrapiEntity<T> {
 	}
 
 	public async getAll(): Promise<T[]> {
-		const response = await this.queryStrapi(this.getPopulates());
-		return this.flattenDataStructure(response.data);
+		const strapiObjects = await this.queryStrapi({populates: this.getPopulates()});
+		return this.flattenDataStructure(strapiObjects);
 	}
 
 	public async findOneBy({ fieldName, value }: IFilter): Promise<T> {
-		const data = await this.findAllBy({ fieldName, value });
-		return data[0];
+		const strapiObjects = await this.findAllBy({ fieldName, value });
+		return strapiObjects[0];
 	}
 
 	public async findAllBy({ fieldName, value }: IFilter): Promise<T[]> {
-		const data = await this.find(fieldName, value);
-		return this.flattenDataStructure(data);
+		const strapiObjects = await this.find(fieldName, value);
+		return this.flattenDataStructure(strapiObjects);
 	}
 
-	public async get({ id }: IID): Promise<T> {
-		const response = await this.queryStrapi({
+	public async get({ id }: IID): Promise<T | null> {
+		const strapiObject = await this.queryStrapi({
 			path: `${this.path}/${id}`,
 			populates: this.getPopulates(),
 		});
-		return this.flattenDataStructure(response.data);
+		if (!strapiObject) {
+			return null;
+		}
+		return this.flattenDataStructure(strapiObject);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,32 +1,33 @@
 {
-  "name": "code-specialist-strapi-client",
-  "version": "0.5.5",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "scripts": {
-    "build": "tsc",
-    "test": "jest"
-  },
-  "dependencies": {
-    "@types/node": "~18.16.3",
-    "axios": "^1.4.0",
-    "typescript": "~5.0.4"
-  },
-  "devDependencies": {
-    "@types/jest": "~29.5.1",
-    "all-contributors-cli": "^6.25.1",
-    "jest": "~29.5.0",
-    "rome": "^12.1.2",
-    "ts-jest": "~29.1.0"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "bail": true,
-    "verbose": true,
-    "collectCoverage": true
-  }
+	"name": "code-specialist-strapi-client",
+	"version": "0.5.5",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"scripts": {
+		"build": "tsc",
+		"test": "jest"
+	},
+	"dependencies": {
+		"@types/node": "~18.16.3",
+		"axios": "^1.4.0",
+		"typescript": "~5.0.4"
+	},
+	"devDependencies": {
+		"@types/jest": "~29.5.1",
+		"all-contributors-cli": "^6.25.1",
+		"jest": "~29.5.0",
+		"rome": "^12.1.2",
+		"ts-jest": "~29.1.0"
+	},
+	"jest": {
+		"preset": "ts-jest",
+		"testEnvironment": "node",
+		"bail": true,
+		"verbose": true,
+		"collectCoverage": true,
+		"collectCoverageFrom": ["lib/strapiClient.ts", "lib/strapiEntity.ts"]
+	}
 }

--- a/tests/strapiEntity/findOneBy.test.ts
+++ b/tests/strapiEntity/findOneBy.test.ts
@@ -1,0 +1,49 @@
+import { StrapiEntity } from "../../lib/strapiEntity";
+
+// Mock AxiosInstance and response data for testing
+const mockClient = {
+	get: jest.fn(),
+};
+
+describe("findOneBy", () => {
+	let entity: StrapiEntity<any>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	beforeAll(() => {
+		// @ts-ignore
+		entity = new StrapiEntity({ client: mockClient, path: "/test" });
+	});
+
+	it("should fetch data from Strapi and return the first result", async () => {
+		// Mock response
+		mockClient.get.mockImplementationOnce(() =>
+			Promise.resolve({
+				data: {
+					metadata: {
+						pagination: {
+							page: 1,
+							pageCount: 1,
+						},
+					},
+					data: [{ id: 1 }, { id: 2 }],
+				},
+			}),
+		);
+
+		const result = await entity.findOneBy({ fieldName: "id", value: "1" });
+
+		expect(mockClient.get).toHaveBeenCalledTimes(1); // Only one request made
+		expect(mockClient.get).toHaveBeenCalledWith("/test", {
+			params: {
+				"filters[id]": "1",
+				"pagination[pageSize]": 25,
+				"pagination[page]": 1,
+			},
+		});
+
+		expect(result).toEqual({ id: 1 });
+	});
+});

--- a/tests/strapiEntity/get.test.ts
+++ b/tests/strapiEntity/get.test.ts
@@ -1,0 +1,100 @@
+import { StrapiEntity } from "../../lib/strapiEntity";
+
+// Mock AxiosInstance and response data for testing
+const mockClient = {
+	get: jest.fn(),
+};
+
+describe("get", () => {
+	let entity: StrapiEntity<any>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should fetch data from Strapi by ID", async () => {
+		// Mock response
+		mockClient.get.mockImplementationOnce(() =>
+			Promise.resolve({
+				data: {
+					id: 1,
+					name: "Test",
+				},
+			}),
+		);
+
+		// @ts-ignore
+		entity = new StrapiEntity({ client: mockClient, path: "/test" });
+		const result = await entity.get({ id: 1 });
+
+		expect(mockClient.get).toHaveBeenCalledTimes(1); // Only one request made
+		expect(mockClient.get).toHaveBeenCalledWith("/test/1", {
+			params: {
+				populate: undefined,
+				"pagination[pageSize]": 25,
+				"pagination[page]": 1,
+			},
+		});
+
+		expect(result).toEqual({ id: 1, name: "Test" });
+	});
+
+	it("should fetch data from Strapi by ID with populates", async () => {
+		// Arrange
+		entity = new StrapiEntity({
+			// @ts-ignore
+			client: mockClient,
+			path: "/test",
+			childEntities: ["relation"],
+		});
+
+		// Mock response
+		mockClient.get.mockImplementationOnce(() =>
+			Promise.resolve({
+				data: {
+					id: 1,
+					name: "Test",
+					relation: {
+						id: 2,
+						name: "Related",
+					},
+				},
+			}),
+		);
+
+		const result = await entity.get({ id: 1 });
+
+		expect(mockClient.get).toHaveBeenCalledTimes(1); // Only one request made
+		expect(mockClient.get).toHaveBeenCalledWith("/test/1", {
+			params: expect.objectContaining({
+				populate: "relation",
+			}),
+		});
+
+		expect(result).toEqual({
+			id: 1,
+			name: "Test",
+			relation: { id: 2, name: "Related" },
+		});
+	});
+
+	it("should return null when no matching result is found", async () => {
+		// Mock response
+		mockClient.get.mockImplementationOnce(() =>
+			Promise.resolve({
+				data: null,
+			}),
+		);
+
+		// @ts-ignore
+		entity = new StrapiEntity({ client: mockClient, path: "/test" });
+		const result = await entity.get({ id: 1 });
+
+		expect(mockClient.get).toHaveBeenCalledTimes(1); // Only one request made
+		expect(mockClient.get).toHaveBeenCalledWith("/test/1", {
+			params: { "pagination[pageSize]": 25, "pagination[page]": 1 },
+		});
+
+		expect(result).toBeNull();
+	});
+});


### PR DESCRIPTION
- Provide a fix for failing requests due to missing populates and filters
- 100% test coverage (line and branch coverage)